### PR TITLE
Port permission bonus features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.artillexstudios</groupId>
     <artifactId>AxAFKZone</artifactId>
-    <version>1.6.3</version>
+    <version>1.7.2</version>
     <packaging>jar</packaging>
 
     <name>AxAFKZone</name>
@@ -58,10 +55,6 @@
                                 <relocation>
                                     <pattern>dev.triumphteam.gui</pattern>
                                     <shadedPattern>com.artillexstudios.axafkzone.libs.gui</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.kyori</pattern>
-                                    <shadedPattern>com.artillexstudios.axafkzone.libs.kyori</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>revxrsal.commands</pattern>
@@ -118,7 +111,7 @@
         <dependency>
             <groupId>com.artillexstudios.axapi</groupId>
             <artifactId>axapi</artifactId>
-            <version>1.4.671</version>
+            <version>1.4.732</version>
             <scope>compile</scope>
             <classifier>all</classifier>
         </dependency>

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -20,7 +20,6 @@ import com.artillexstudios.axapi.libs.boostedyaml.settings.updater.UpdaterSettin
 import com.artillexstudios.axapi.metrics.AxMetrics;
 import com.artillexstudios.axapi.utils.MessageUtils;
 import com.artillexstudios.axapi.utils.featureflags.FeatureFlags;
-import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bstats.bukkit.Metrics;
 
 import java.io.File;
@@ -31,7 +30,6 @@ public final class AxAFKZone extends AxPlugin {
     public static MessageUtils MESSAGEUTILS;
     private static AxPlugin instance;
     private static ThreadedQueue<Runnable> threadedQueue;
-    public static BukkitAudiences BUKKITAUDIENCES;
     private static AxMetrics metrics;
 
     public static ThreadedQueue<Runnable> getThreadedQueue() {
@@ -58,7 +56,6 @@ public final class AxAFKZone extends AxPlugin {
 
         threadedQueue = new ThreadedQueue<>("AxAFKZone-Datastore-thread");
 
-        BUKKITAUDIENCES = BukkitAudiences.create(this);
         Commands.registerCommand();
         FileUtils.loadAll();
 
@@ -71,8 +68,8 @@ public final class AxAFKZone extends AxPlugin {
         if (CONFIG.getBoolean("update-notifier.enabled", true)) new UpdateNotifier(this, 6598);
     }
 
-    public void updateFlags(FeatureFlags flags) {
-        flags.USE_LEGACY_HEX_FORMATTER.set(true);
+    public void updateFlags() {
+        FeatureFlags.USE_LEGACY_HEX_FORMATTER.set(true);
     }
 
     public void disable() {

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -3,6 +3,7 @@ package com.artillexstudios.axafkzone;
 import com.artillexstudios.axafkzone.commands.Commands;
 import com.artillexstudios.axafkzone.listeners.WandListeners;
 import com.artillexstudios.axafkzone.listeners.WorldListeners;
+import com.artillexstudios.axafkzone.listeners.PlayerListeners;
 import com.artillexstudios.axafkzone.schedulers.TickZones;
 import com.artillexstudios.axafkzone.utils.FileUtils;
 import com.artillexstudios.axafkzone.utils.NumberUtils;
@@ -61,6 +62,7 @@ public final class AxAFKZone extends AxPlugin {
 
         getServer().getPluginManager().registerEvents(new WandListeners(), this);
         getServer().getPluginManager().registerEvents(new WorldListeners(), this);
+        getServer().getPluginManager().registerEvents(new PlayerListeners(), this);
 
         metrics = new AxMetrics(this, 9);
         metrics.start();

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -4,6 +4,7 @@ import com.artillexstudios.axafkzone.commands.Commands;
 import com.artillexstudios.axafkzone.listeners.WandListeners;
 import com.artillexstudios.axafkzone.listeners.WorldListeners;
 import com.artillexstudios.axafkzone.listeners.PlayerListeners;
+import com.artillexstudios.axafkzone.placeholder.ZoneExpansion;
 import com.artillexstudios.axafkzone.schedulers.TickZones;
 import com.artillexstudios.axafkzone.utils.FileUtils;
 import com.artillexstudios.axafkzone.utils.NumberUtils;
@@ -22,6 +23,7 @@ import com.artillexstudios.axapi.metrics.AxMetrics;
 import com.artillexstudios.axapi.utils.MessageUtils;
 import com.artillexstudios.axapi.utils.featureflags.FeatureFlags;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
 
 import java.io.File;
 
@@ -54,6 +56,10 @@ public final class AxAFKZone extends AxPlugin {
         TickZones.start();
 
         MESSAGEUTILS = new MessageUtils(LANG.getBackingDocument(), "prefix", CONFIG.getBackingDocument());
+
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new ZoneExpansion().register();
+        }
 
         threadedQueue = new ThreadedQueue<>("AxAFKZone-Datastore-thread");
 

--- a/src/main/java/com/artillexstudios/axafkzone/listeners/PlayerListeners.java
+++ b/src/main/java/com/artillexstudios/axafkzone/listeners/PlayerListeners.java
@@ -1,0 +1,31 @@
+package com.artillexstudios.axafkzone.listeners;
+
+import com.artillexstudios.axafkzone.zones.Zone;
+import com.artillexstudios.axafkzone.zones.Zones;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class PlayerListeners implements Listener {
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        handleLeave(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onKick(PlayerKickEvent event) {
+        handleLeave(event.getPlayer());
+    }
+
+    private void handleLeave(Player player) {
+        for (Zone zone : Zones.getZones().values()) {
+            if (zone.hasPlayer(player)) {
+                zone.forceLeave(player);
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/placeholder/ZoneExpansion.java
+++ b/src/main/java/com/artillexstudios/axafkzone/placeholder/ZoneExpansion.java
@@ -1,0 +1,44 @@
+package com.artillexstudios.axafkzone.placeholder;
+
+import com.artillexstudios.axafkzone.AxAFKZone;
+import com.artillexstudios.axafkzone.utils.TimeUtils;
+import com.artillexstudios.axafkzone.zones.Zone;
+import com.artillexstudios.axafkzone.zones.Zones;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class ZoneExpansion extends PlaceholderExpansion {
+    @Override
+    public @NotNull String getIdentifier() {
+        return "axafkzone";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "ArtillexStudios";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return AxAFKZone.getInstance().getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, @NotNull String params) {
+        if (player == null) return "";
+        int idx = params.lastIndexOf('_');
+        if (idx == -1) return "";
+        String zoneName = params.substring(0, idx);
+        String key = params.substring(idx + 1);
+        Zone zone = Zones.getZoneByName(zoneName);
+        if (zone == null) return "";
+        long time = zone.timeUntilNext(player);
+        long total = zone.getSettings().getInt("reward-time-seconds") * 1000L;
+        return switch (key.toLowerCase()) {
+            case "time" -> TimeUtils.fancyTime(time, total);
+            case "percent" -> TimeUtils.fancyTimePercentage(time, total);
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/utils/PlaceholderUtils.java
+++ b/src/main/java/com/artillexstudios/axafkzone/utils/PlaceholderUtils.java
@@ -1,0 +1,25 @@
+package com.artillexstudios.axafkzone.utils;
+
+import com.artillexstudios.axafkzone.zones.Zone;
+import com.artillexstudios.axafkzone.zones.Zones;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class PlaceholderUtils {
+    private static final boolean HAS_PAPI = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
+
+    public static String applyPlaceholders(Player player, String text) {
+        if (text == null) return null;
+        for (Zone zone : Zones.getZones().values()) {
+            long time = zone.timeUntilNext(player);
+            long total = zone.getSettings().getInt("reward-time-seconds") * 1000L;
+            text = text.replace("%" + zone.getName() + "-time%", TimeUtils.fancyTime(time, total));
+            text = text.replace("%" + zone.getName() + "-time-percent%", TimeUtils.fancyTimePercentage(time, total));
+        }
+        if (HAS_PAPI) {
+            text = PlaceholderAPI.setPlaceholders(player, text);
+        }
+        return text;
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/utils/RandomUtils.java
+++ b/src/main/java/com/artillexstudios/axafkzone/utils/RandomUtils.java
@@ -18,4 +18,14 @@ public class RandomUtils {
 
         return e.sample();
     }
+
+    /**
+     * Returns whether a roll is successful based on the supplied percentage.
+     *
+     * @param chance chance from 0-100
+     * @return true if the random roll succeeds
+     */
+    public static boolean getChance(double chance) {
+        return Math.random() * 100 < chance;
+    }
 }

--- a/src/main/java/com/artillexstudios/axafkzone/utils/TimeUtils.java
+++ b/src/main/java/com/artillexstudios/axafkzone/utils/TimeUtils.java
@@ -8,8 +8,7 @@ import static com.artillexstudios.axafkzone.AxAFKZone.CONFIG;
 import static com.artillexstudios.axafkzone.AxAFKZone.LANG;
 
 public class TimeUtils {
-    public static @NotNull String fancyTime(long time) {
-
+    public static @NotNull String fancyTime(long time, long totalTime) {
         if (time < 0) return "---";
 
         final Duration remainingTime = Duration.ofMillis(time);
@@ -28,12 +27,24 @@ public class TimeUtils {
             if (hours > 0) return hours + LANG.getString("time.hour", "h");
             if (minutes > 0) return minutes + LANG.getString("time.minute", "m");
             return seconds + LANG.getString("time.second", "s");
-        } else {
+        } else if (CONFIG.getInt("timer-format", 1) == 3) {
             if (days > 0)
                 return String.format("%02d" + LANG.getString("time.day", "d") + " %02d" + LANG.getString("time.hour", "h") + " %02d" + LANG.getString("time.minute", "m") + " %02d" + LANG.getString("time.second", "s"), days, hours, minutes, seconds);
             if (hours > 0)
                 return String.format("%02d" + LANG.getString("time.hour", "h") + " %02d" + LANG.getString("time.minute", "m") + " %02d" + LANG.getString("time.second", "s"), hours, minutes, seconds);
             return String.format("%02d" + LANG.getString("time.minute", "m") + " %02d" + LANG.getString("time.second", "s"), minutes, seconds);
+        } else if (CONFIG.getInt("timer-format", 1) == 4) {
+            return fancyTimePercentage(time, totalTime);
         }
+
+        return "---";
+    }
+
+    public static @NotNull String fancyTimePercentage(long time, long totalTime) {
+        if (totalTime > 0) {
+            double percentage = ((double) (totalTime - time) / totalTime) * 100;
+            return String.format("%.2f%%", percentage);
+        }
+        return "---";
     }
 }

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -182,8 +182,31 @@ public class Zone {
         if (bossBar != null) bossBar.remove();
         Distances dist = distances.remove(player);
         if (dist != null) {
-            setViewDistance(player, dist.view());
-            setSimulationDistance(player, dist.simulation());
+            setViewDistance(player, player.getServer().getViewDistance());
+            setSimulationDistance(player, player.getServer().getSimulationDistance());
+        }
+    }
+
+    public boolean hasPlayer(Player player) {
+        return zonePlayers.containsKey(player);
+    }
+
+    public void forceLeave(Player player) {
+        Integer time = zonePlayers.remove(player);
+        if (time == null) return;
+
+        if (player.isOnline())
+            msg.sendLang(player, "messages.left", Map.of(
+                    "%time%", TimeUtils.fancyTime(time * 1_000L, rewardSeconds * 1_000L),
+                    "%time-percent%", TimeUtils.fancyTimePercentage(time * 1_000L, rewardSeconds * 1_000L)
+            ));
+
+        BossBar bossBar = bossbars.remove(player);
+        if (bossBar != null) bossBar.remove();
+        Distances dist = distances.remove(player);
+        if (dist != null) {
+            setViewDistance(player, player.getServer().getViewDistance());
+            setSimulationDistance(player, player.getServer().getSimulationDistance());
         }
     }
 
@@ -358,8 +381,8 @@ public class Zone {
             Player player = entry.getKey();
             Distances dist = entry.getValue();
             if (player.isOnline()) {
-                setViewDistance(player, dist.view());
-                setSimulationDistance(player, dist.simulation());
+                setViewDistance(player, player.getServer().getViewDistance());
+                setSimulationDistance(player, player.getServer().getSimulationDistance());
             }
         }
         distances.clear();

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -4,6 +4,7 @@ import com.artillexstudios.axafkzone.reward.Reward;
 import com.artillexstudios.axafkzone.selection.Region;
 import com.artillexstudios.axafkzone.utils.RandomUtils;
 import com.artillexstudios.axafkzone.utils.TimeUtils;
+import com.artillexstudios.axafkzone.utils.PlaceholderUtils;
 import com.artillexstudios.axapi.config.Config;
 import com.artillexstudios.axapi.libs.boostedyaml.block.implementation.Section;
 import com.artillexstudios.axapi.serializers.Serializers;
@@ -249,16 +250,16 @@ public class Zone {
             Reward exampleReward = rewards.peek();
             double chance = exampleReward == null ? 0.0 : getPlayerChance(player, exampleReward);
             Title title = Title.create(
-                    zoneTitle == null ? Component.empty() : StringUtils.format(zoneTitle
+                    zoneTitle == null ? Component.empty() : StringUtils.format(PlaceholderUtils.applyPlaceholders(player, zoneTitle
                             .replace("%time%", TimeUtils.fancyTime(timeUntilNext(player), rewardSeconds * 1_000L))
                             .replace("%time-percent%", TimeUtils.fancyTimePercentage(timeUntilNext(player), rewardSeconds * 1_000L))
                             .replace("%chance%", String.format("%.2f%%", chance))
-                    ),
-                    zoneSubTitle == null ? Component.empty() : StringUtils.format(zoneSubTitle
+                    )),
+                    zoneSubTitle == null ? Component.empty() : StringUtils.format(PlaceholderUtils.applyPlaceholders(player, zoneSubTitle
                             .replace("%time%", TimeUtils.fancyTime(timeUntilNext(player), rewardSeconds * 1_000L))
                             .replace("%time-percent%", TimeUtils.fancyTimePercentage(timeUntilNext(player), rewardSeconds * 1_000L))
                             .replace("%chance%", String.format("%.2f%%", chance))
-                    ),
+                    )),
                     0, 10, 0
             );
             title.send(player);
@@ -270,11 +271,11 @@ public class Zone {
         if (zoneActionbar != null && !zoneActionbar.isBlank()) {
             Reward exampleReward = rewards.peek();
             double chance = exampleReward == null ? 0.0 : getPlayerChance(player, exampleReward);
-            ActionBar.send(player, StringUtils.format(zoneActionbar
+            ActionBar.send(player, StringUtils.format(PlaceholderUtils.applyPlaceholders(player, zoneActionbar
                     .replace("%time%", TimeUtils.fancyTime(timeUntilNext(player), rewardSeconds * 1_000L))
                     .replace("%time-percent%", TimeUtils.fancyTimePercentage(timeUntilNext(player), rewardSeconds * 1_000L))
                     .replace("%chance%", String.format("%.2f%%", chance))
-            ));
+            )));
         }
     }
 
@@ -292,11 +293,11 @@ public class Zone {
         if ((section = settings.getSection("in-zone.bossbar")) != null) {
             Reward exampleReward = rewards.peek();
             double chance = exampleReward == null ? 0.0 : getPlayerChance(player, exampleReward);
-            bossBar.title(StringUtils.format(section.getString("name")
+            bossBar.title(StringUtils.format(PlaceholderUtils.applyPlaceholders(player, section.getString("name")
                     .replace("%time%", TimeUtils.fancyTime(timeUntilNext(player), rewardSeconds * 1_000L))
                     .replace("%time-percent%", TimeUtils.fancyTimePercentage(timeUntilNext(player), rewardSeconds * 1_000L))
                     .replace("%chance%", String.format("%.2f%%", chance))
-            ));
+            )));
         }
     }
 
@@ -321,18 +322,20 @@ public class Zone {
 
             if (string.contains("%reward%")) {
                 for (Reward reward : rewardList) {
-                    player.sendMessage(StringUtils.formatToString(string, Map.of(
+                    String msgStr = StringUtils.formatToString(string, Map.of(
                             "%reward%", Optional.ofNullable(reward.getDisplay()).orElse("---"),
                             "%time%", TimeUtils.fancyTime(newTime * 1_000L, rewardSeconds * 1_000L),
                             "%time-percent%", TimeUtils.fancyTimePercentage(newTime * 1_000L, rewardSeconds * 1_000L)
-                    )));
+                    ));
+                    player.sendMessage(PlaceholderUtils.applyPlaceholders(player, msgStr));
                 }
                 continue;
             }
-            player.sendMessage(StringUtils.formatToString(string, Map.of(
+            String msgStr = StringUtils.formatToString(string, Map.of(
                     "%time%", TimeUtils.fancyTime(newTime * 1_000L, rewardSeconds * 1_000L),
                     "%time-percent%", TimeUtils.fancyTimePercentage(newTime * 1_000L, rewardSeconds * 1_000L)
-            )));
+            ));
+            player.sendMessage(PlaceholderUtils.applyPlaceholders(player, msgStr));
         }
     }
 

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -348,22 +348,31 @@ public class Zone {
         }
 
         double highestBonus = 0.0;
+        double personalBonus = 0.0;
 
         for (PermissionAttachmentInfo info : player.getEffectivePermissions()) {
             String perm = info.getPermission();
-            if (!perm.startsWith("afkzone-bonus-")) continue;
-            String value = perm.substring("afkzone-bonus-".length());
-            try {
-                double bonus = Double.parseDouble(value);
-                if (bonus > highestBonus) {
-                    highestBonus = bonus;
+            if (perm.startsWith("afkzone-bonus-")) {
+                String value = perm.substring("afkzone-bonus-".length());
+                try {
+                    double bonus = Double.parseDouble(value);
+                    if (bonus > highestBonus) {
+                        highestBonus = bonus;
+                    }
+                } catch (NumberFormatException ignored) {
                 }
-            } catch (NumberFormatException ignored) {
+            } else if (perm.startsWith("afkzone-personal-bonus-")) {
+                String value = perm.substring("afkzone-personal-bonus-".length());
+                try {
+                    personalBonus += Double.parseDouble(value);
+                } catch (NumberFormatException ignored) {
+                }
             }
         }
 
-        bonusCache.put(player, highestBonus);
-        return highestBonus;
+        double totalBonus = highestBonus + personalBonus;
+        bonusCache.put(player, totalBonus);
+        return totalBonus;
     }
 
     private double getPlayerChance(Player player, Reward reward) {

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -150,6 +150,16 @@ public class Zone {
                 "%time%", TimeUtils.fancyTime(rewardSeconds * 1_000L, rewardSeconds * 1_000L),
                 "%time-percent%", TimeUtils.fancyTimePercentage(rewardSeconds * 1_000L, rewardSeconds * 1_000L)
         ));
+        String enterSoundName = CONFIG.getString("sounds.enter", "ENTITY_FIREWORK_ROCKET_TWINKLE");
+        try {
+            player.playSound(player.getLocation(), org.bukkit.Sound.valueOf(enterSoundName), 0.4f, 3f);
+        } catch (IllegalArgumentException ignored) {
+        }
+        String enterParticle = CONFIG.getString("effects.enter", "POOF");
+        try {
+            player.getWorld().spawnParticle(org.bukkit.Particle.valueOf(enterParticle), player.getLocation(), 10, 0.3, 0.5, 0.3, 0);
+        } catch (IllegalArgumentException ignored) {
+        }
         zonePlayers.put(player, 0);
 
         Section section;
@@ -172,11 +182,22 @@ public class Zone {
     }
 
     private void leave(Player player, Iterator<Map.Entry<Player, Integer>> it) {
-        if (player.isOnline())
+        if (player.isOnline()) {
             msg.sendLang(player, "messages.left", Map.of(
                     "%time%", TimeUtils.fancyTime(zonePlayers.get(player) * 1_000L, rewardSeconds * 1_000L),
                     "%time-percent%", TimeUtils.fancyTimePercentage(zonePlayers.get(player) * 1_000L, rewardSeconds * 1_000L)
             ));
+            String leaveSoundName = CONFIG.getString("sounds.leave", "ENTITY_FIREWORK_ROCKET_TWINKLE");
+            try {
+                player.playSound(player.getLocation(), org.bukkit.Sound.valueOf(leaveSoundName), 0.4f, 3f);
+            } catch (IllegalArgumentException ignored) {
+            }
+            String leaveParticle = CONFIG.getString("effects.leave", "POOF");
+            try {
+                player.getWorld().spawnParticle(org.bukkit.Particle.valueOf(leaveParticle), player.getLocation(), 10, 0.3, 0.5, 0.3, 0);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
         it.remove();
         BossBar bossBar = bossbars.remove(player);
         if (bossBar != null) bossBar.remove();
@@ -195,11 +216,22 @@ public class Zone {
         Integer time = zonePlayers.remove(player);
         if (time == null) return;
 
-        if (player.isOnline())
+        if (player.isOnline()) {
             msg.sendLang(player, "messages.left", Map.of(
                     "%time%", TimeUtils.fancyTime(time * 1_000L, rewardSeconds * 1_000L),
                     "%time-percent%", TimeUtils.fancyTimePercentage(time * 1_000L, rewardSeconds * 1_000L)
             ));
+            String leaveSoundName = CONFIG.getString("sounds.leave", "ENTITY_FIREWORK_ROCKET_TWINKLE");
+            try {
+                player.playSound(player.getLocation(), org.bukkit.Sound.valueOf(leaveSoundName), 0.4f, 3f);
+            } catch (IllegalArgumentException ignored) {
+            }
+            String leaveParticle = CONFIG.getString("effects.leave", "POOF");
+            try {
+                player.getWorld().spawnParticle(org.bukkit.Particle.valueOf(leaveParticle), player.getLocation(), 10, 0.3, 0.5, 0.3, 0);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
 
         BossBar bossBar = bossbars.remove(player);
         if (bossBar != null) bossBar.remove();
@@ -270,6 +302,13 @@ public class Zone {
 
     private void handleRewards(Player player, int newTime) {
         final List<Reward> rewardList = giveRewards(player);
+        if (!rewardList.isEmpty()) {
+            String rewardSoundName = CONFIG.getString("sounds.reward", "ENTITY_VILLAGER_TRADE");
+            try {
+                player.playSound(player.getLocation(), org.bukkit.Sound.valueOf(rewardSoundName), 0.4f, 2f);
+            } catch (IllegalArgumentException ignored) {
+            }
+        }
         if (settings.getStringList("messages.reward").isEmpty()) return;
 
         final String prefix = CONFIG.getString("prefix");

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -209,7 +210,7 @@ public class Zone {
             if (string.contains("%reward%")) {
                 for (Reward reward : rewardList) {
                     player.sendMessage(StringUtils.formatToString(string, Map.of(
-                            "%reward%", reward.getDisplay(),
+                            "%reward%", Optional.ofNullable(reward.getDisplay()).orElse("---"),
                             "%time%", TimeUtils.fancyTime(newTime * 1_000L, rewardSeconds * 1_000L),
                             "%time-percent%", TimeUtils.fancyTimePercentage(newTime * 1_000L, rewardSeconds * 1_000L)
                     )));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,17 @@ reset-after-reward: true
 # set to -1 for unlimited
 zone-per-ip-limit: -1
 
+# sounds played on various events
+sounds:
+  enter: "ENTITY_FIREWORK_ROCKET_TWINKLE"
+  leave: "ENTITY_FIREWORK_ROCKET_TWINKLE"
+  reward: "ENTITY_VILLAGER_TRADE"
+
+# particles spawned on events
+effects:
+  enter: "POOF"
+  leave: "POOF"
+
 # should the bossbar progress start from full or empty?
 # directions:
 # 0 - decreasing value (starts filled)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,7 +3,8 @@ prefix: "<gradient:#FF8800:#CC0055><b>AxAFKZone</b></gradient> &7» "
 # 1 - HH:MM:SS, for example 01:25:35
 # 2 - short format, for example 20m
 # 3 - text format, for example 01h 25m 35s
-timer-format: 1
+# 4 - percentage format
+timer-format: 2
 
 # you must define at least 1
 # requires a restart to update
@@ -14,7 +15,7 @@ command-aliases:
 
 # should the timer reset after a player gets their afk zone rewards?
 # this is just for the placeholders, it will not change functionality
-reset-after-reward: false
+reset-after-reward: true
 
 # how many players can gain rewards at once from a single ip?
 # set to -1 for unlimited

--- a/src/main/resources/zones/example-zone.yml
+++ b/src/main/resources/zones/example-zone.yml
@@ -8,16 +8,14 @@ messages:
 
 # set any of the lines to "" if you want to disable one of them
 in-zone:
-  title: "&#CC0055⌚ &7| &#FF8855ʏᴏᴜ ᴀʀᴇ ᴀғᴋ &7| &#CC0055⌚"
-  subtitle: "&#FFBB00Next reward in: &#CC0055%time%"
-  actionbar: ""
+  title: '&8⋆ &#279EFF&lꜱ&#2BABFF&lᴛ&#2EB8FF&lʀ&#32C5FF&lᴇ&#35D2FF&lꜰ&#39DFFF&lᴀ &#30BFFF&lᴀ&#2CAEFF&lꜰ&#279EFF&lᴋ&8 ⋆'
+  subtitle: '&fPostęp: &8(&#55ffff%time-percent%&8)'
+  actionbar: ''
   # remove the section to disable
   bossbar:
-    name: "&#CC0055⌚ &7| &#FF8855ʏᴏᴜ ᴀʀᴇ ᴀғᴋ &7| &#FFBB00Next reward in: &#CC0055%time%"
-    # colors: https://javadoc.io/static/net.kyori/adventure-api/4.17.0/net/kyori/adventure/bossbar/BossBar.Color.html
-    color: RED
-    # styles: https://javadoc.io/static/net.kyori/adventure-api/4.17.0/net/kyori/adventure/bossbar/BossBar.Overlay.html
-    style: NOTCHED_20
+    name: '&fdostaniesz za: &#55ffff%time% &8(&#55ffff%time-percent%&8) &8| &fSzansa: &#55ffff%chance%'
+    color: BLUE
+    style: PROGRESS
 
 # the required permission to gain rewards in this zone
 # example: axafkzone.vip
@@ -28,7 +26,7 @@ permission: ""
 reward-time-seconds: 60
 
 # how many rewards should be rolled after the time has passed?
-roll-amount: 3
+roll-amount: 1
 
 # chances can go over 100%
 # you can add as many rewards as you would like
@@ -42,6 +40,14 @@ rewards:
     items:
       - amount: 1
         material: diamond
+
+bonus-permissions:
+  afkzone-bonus-5: 5.0
+  afkzone-bonus-10: 10.0
+  afkzone-bonus-20: 20.0
+  afkzone-bonus-30: 30.0
+  afkzone-bonus-40: 40.0
+  afkzone-bonus-50: 50.0
 
 zone:
   location1: "IF YOU SEE THIS, SOMETHING HAS GONE REALLY REALLY WRONG"

--- a/src/main/resources/zones/example-zone.yml
+++ b/src/main/resources/zones/example-zone.yml
@@ -41,13 +41,7 @@ rewards:
       - amount: 1
         material: diamond
 
-bonus-permissions:
-  afkzone-bonus-5: 5.0
-  afkzone-bonus-10: 10.0
-  afkzone-bonus-20: 20.0
-  afkzone-bonus-30: 30.0
-  afkzone-bonus-40: 40.0
-  afkzone-bonus-50: 50.0
+# Grant permissions like "afkzone-bonus-5" to increase reward chances
 
 zone:
   location1: "IF YOU SEE THIS, SOMETHING HAS GONE REALLY REALLY WRONG"

--- a/src/main/resources/zones/example-zone.yml
+++ b/src/main/resources/zones/example-zone.yml
@@ -42,6 +42,7 @@ rewards:
         material: diamond
 
 # Grant permissions like "afkzone-bonus-5" to increase reward chances
+# "afkzone-personal-bonus-*" can stack with the group bonus
 
 zone:
   location1: "IF YOU SEE THIS, SOMETHING HAS GONE REALLY REALLY WRONG"


### PR DESCRIPTION
## Summary
- re-add permission-based chance bonuses and percentage timers
- show chance info in titles, actionbars and boss bars
- update example configs for new placeholders

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857f71a87bc832fb3060fe9aa75d451