### PR TITLE
Add per-zone tracking range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.artillexstudios.axapi</groupId>
             <artifactId>axapi</artifactId>
             <version>1.4.732</version>

--- a/src/main/java/com/artillexstudios/axafkzone/tracking/TrackingRangeManager.java
+++ b/src/main/java/com/artillexstudios/axafkzone/tracking/TrackingRangeManager.java
@@ -1,0 +1,71 @@
+package com.artillexstudios.axafkzone.tracking;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Utility class used to modify the tracking range of players when they are
+ * inside an AFK zone. This uses Paper specific API when available and falls
+ * back to reflection otherwise.
+ */
+public class TrackingRangeManager {
+    private static final Map<Player, Integer> originalRanges = new ConcurrentHashMap<>();
+
+    private static Method setRangeMethod;
+    private static Method getRangeMethod;
+
+    static {
+        try {
+            setRangeMethod = Player.class.getMethod("setEntityTrackingRange", int.class);
+            getRangeMethod = Player.class.getMethod("getEntityTrackingRange");
+        } catch (NoSuchMethodException ignored) {
+            setRangeMethod = null;
+            getRangeMethod = null;
+        }
+    }
+
+    /**
+     * Set the player's tracking range to the supplied value while remembering
+     * the previous range so that it can be restored later.
+     *
+     * @param player player to modify
+     * @param range  new tracking range
+     */
+    public static void applyAfkRange(Player player, int range) {
+        if (setRangeMethod == null) return;
+        if (!originalRanges.containsKey(player)) {
+            try {
+                int current = (int) getRangeMethod.invoke(player);
+                originalRanges.put(player, current);
+            } catch (Exception ex) {
+                // ignore if we cannot fetch current range
+            }
+        }
+
+        try {
+            setRangeMethod.invoke(player, range);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+     * Restore the player's tracking range if previously modified by
+     * {@link #applyAfkRange(Player, int)}.
+     *
+     * @param player player to restore
+     */
+    public static void restoreRange(Player player) {
+        Integer original = originalRanges.remove(player);
+        if (original == null || setRangeMethod == null) return;
+        try {
+            setRangeMethod.invoke(player, original);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -15,6 +15,7 @@ import com.artillexstudios.axapi.utils.StringUtils;
 import com.artillexstudios.axapi.utils.Title;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
+import com.artillexstudios.axafkzone.tracking.TrackingRangeManager;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -106,6 +107,7 @@ public class Zone {
                 "%time-percent%", TimeUtils.fancyTimePercentage(rewardSeconds * 1_000L, rewardSeconds * 1_000L)
         ));
         zonePlayers.put(player, 0);
+        TrackingRangeManager.applyAfkRange(player, 1);
 
         Section section;
         if ((section = settings.getSection("in-zone.bossbar")) != null) {
@@ -135,6 +137,7 @@ public class Zone {
         it.remove();
         BossBar bossBar = bossbars.remove(player);
         if (bossBar != null) bossBar.remove();
+        TrackingRangeManager.restoreRange(player);
     }
 
     private void sendTitle(Player player) {
@@ -303,6 +306,7 @@ public class Zone {
         for (BossBar bossBar : bossbars.values()) {
             bossBar.remove();
         }
+        zonePlayers.keySet().forEach(TrackingRangeManager::restoreRange);
     }
 
     public void setRegion(Region region) {


### PR DESCRIPTION
## Summary
- add `TrackingRangeManager` to change player entity tracking range
- adjust tracking range when players enter/leave zones
- restore tracking range when a zone is disabled
- include Paper API

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download maven resources)*

------
https://chatgpt.com/codex/tasks/task_e_687bf60adde0832f8ff9899b919d80ce