### PR TITLE
Add ProtocolLib tracking for AFK zones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>protocol-lib</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -143,6 +147,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -7,6 +7,7 @@ import com.artillexstudios.axafkzone.schedulers.TickZones;
 import com.artillexstudios.axafkzone.utils.FileUtils;
 import com.artillexstudios.axafkzone.utils.NumberUtils;
 import com.artillexstudios.axafkzone.utils.UpdateNotifier;
+import com.artillexstudios.axafkzone.listeners.TrackingRangeListener;
 import com.artillexstudios.axafkzone.zones.Zone;
 import com.artillexstudios.axafkzone.zones.Zones;
 import com.artillexstudios.axapi.AxPlugin;
@@ -58,6 +59,8 @@ public final class AxAFKZone extends AxPlugin {
 
         Commands.registerCommand();
         FileUtils.loadAll();
+
+        TrackingRangeListener.init(this);
 
         getServer().getPluginManager().registerEvents(new WandListeners(), this);
         getServer().getPluginManager().registerEvents(new WorldListeners(), this);

--- a/src/main/java/com/artillexstudios/axafkzone/listeners/TrackingRangeListener.java
+++ b/src/main/java/com/artillexstudios/axafkzone/listeners/TrackingRangeListener.java
@@ -1,0 +1,59 @@
+package com.artillexstudios.axafkzone.listeners;
+
+import com.artillexstudios.axafkzone.AxAFKZone;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketContainer;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class TrackingRangeListener extends PacketAdapter {
+    private static final Set<Player> limited = ConcurrentHashMap.newKeySet();
+
+    public static void init(AxAFKZone plugin) {
+        ProtocolManager manager = ProtocolLibrary.getProtocolManager();
+        manager.addPacketListener(new TrackingRangeListener(plugin));
+    }
+
+    public static void add(Player player) {
+        limited.add(player);
+    }
+
+    public static void remove(Player player) {
+        limited.remove(player);
+    }
+
+    private TrackingRangeListener(AxAFKZone plugin) {
+        super(plugin, ListenerPriority.NORMAL,
+                PacketType.Play.Server.NAMED_ENTITY_SPAWN,
+                PacketType.Play.Server.SPAWN_ENTITY,
+                PacketType.Play.Server.ENTITY_TELEPORT,
+                PacketType.Play.Server.REL_ENTITY_MOVE,
+                PacketType.Play.Server.REL_ENTITY_MOVE_LOOK,
+                PacketType.Play.Server.ENTITY_METADATA,
+                PacketType.Play.Server.ENTITY_HEAD_ROTATION);
+    }
+
+    @Override
+    public void onPacketSending(PacketEvent event) {
+        Player receiver = event.getPlayer();
+        if (!limited.contains(receiver)) return;
+
+        PacketContainer packet = event.getPacket();
+        Entity entity = packet.getEntityModifier(receiver.getWorld()).readSafely(0);
+        if (entity == null || !(entity instanceof Player) || entity.equals(receiver)) {
+            return;
+        }
+
+        if (receiver.getLocation().distanceSquared(entity.getLocation()) > 1.0) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -15,6 +15,7 @@ import com.artillexstudios.axapi.utils.StringUtils;
 import com.artillexstudios.axapi.utils.Title;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
+import com.artillexstudios.axafkzone.listeners.TrackingRangeListener;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -107,6 +108,8 @@ public class Zone {
         ));
         zonePlayers.put(player, 0);
 
+        TrackingRangeListener.add(player);
+
         Section section;
         if ((section = settings.getSection("in-zone.bossbar")) != null) {
             Reward exampleReward = rewards.peek();
@@ -135,6 +138,7 @@ public class Zone {
         it.remove();
         BossBar bossBar = bossbars.remove(player);
         if (bossBar != null) bossBar.remove();
+        TrackingRangeListener.remove(player);
     }
 
     private void sendTitle(Player player) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '${project.version}'
 main: com.artillexstudios.axafkzone.AxAFKZone
 api-version: '1.20'
 folia-supported: true
+softdepend: [ProtocolLib]
 
 permissions:
   axafkzone.admin:


### PR DESCRIPTION
## Summary
- include ProtocolLib as provided dependency
- register packet listener for per-player tracking range
- hook zone enter/leave to toggle tracking
- declare softdepend on ProtocolLib

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bfdd76fa4832f8acfdcd5a2e6c7fd