### PR TITLE
Add ProtocolLib based tracking limiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -143,6 +147,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/AxAFKZone.java
@@ -9,6 +9,7 @@ import com.artillexstudios.axafkzone.utils.NumberUtils;
 import com.artillexstudios.axafkzone.utils.UpdateNotifier;
 import com.artillexstudios.axafkzone.zones.Zone;
 import com.artillexstudios.axafkzone.zones.Zones;
+import com.artillexstudios.axafkzone.tracking.TrackingRangeManager;
 import com.artillexstudios.axapi.AxPlugin;
 import com.artillexstudios.axapi.config.Config;
 import com.artillexstudios.axapi.executor.ThreadedQueue;
@@ -51,6 +52,7 @@ public final class AxAFKZone extends AxPlugin {
 
         NumberUtils.reload();
         TickZones.start();
+        TrackingRangeManager.init(this);
 
         MESSAGEUTILS = new MessageUtils(LANG.getBackingDocument(), "prefix", CONFIG.getBackingDocument());
 

--- a/src/main/java/com/artillexstudios/axafkzone/tracking/TrackingRangeManager.java
+++ b/src/main/java/com/artillexstudios/axafkzone/tracking/TrackingRangeManager.java
@@ -1,0 +1,64 @@
+package com.artillexstudios.axafkzone.tracking;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple manager that limits entity update packets for players that should have
+ * reduced tracking range. Packets about other players farther than one block
+ * from the receiver are cancelled.
+ */
+public final class TrackingRangeManager {
+    private static final Set<UUID> limited = ConcurrentHashMap.newKeySet();
+    private static ProtocolManager manager;
+
+    private TrackingRangeManager() {
+    }
+
+    public static void init(Plugin plugin) {
+        manager = ProtocolLibrary.getProtocolManager();
+        manager.addPacketListener(new PacketAdapter(plugin, PacketType.Play.Server.NAMED_ENTITY_SPAWN,
+                PacketType.Play.Server.REL_ENTITY_MOVE,
+                PacketType.Play.Server.REL_ENTITY_MOVE_LOOK,
+                PacketType.Play.Server.ENTITY_TELEPORT) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                Player receiver = event.getPlayer();
+                if (!limited.contains(receiver.getUniqueId())) return;
+
+                int entityId = event.getPacket().getIntegers().read(0);
+                Entity entity = manager.getEntityFromID(receiver.getWorld(), entityId);
+                if (!(entity instanceof Player other)) return;
+                if (other.equals(receiver)) return;
+
+                if (other.getLocation().distanceSquared(receiver.getLocation()) > 1) {
+                    event.setCancelled(true);
+                }
+            }
+        });
+    }
+
+    public static void apply(Player player) {
+        limited.add(player.getUniqueId());
+    }
+
+    public static void reset(Player player) {
+        limited.remove(player.getUniqueId());
+    }
+
+    public static boolean isLimited(Player player) {
+        return limited.contains(player.getUniqueId());
+    }
+}

--- a/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
+++ b/src/main/java/com/artillexstudios/axafkzone/zones/Zone.java
@@ -4,6 +4,7 @@ import com.artillexstudios.axafkzone.reward.Reward;
 import com.artillexstudios.axafkzone.selection.Region;
 import com.artillexstudios.axafkzone.utils.RandomUtils;
 import com.artillexstudios.axafkzone.utils.TimeUtils;
+import com.artillexstudios.axafkzone.tracking.TrackingRangeManager;
 import com.artillexstudios.axapi.config.Config;
 import com.artillexstudios.axapi.libs.boostedyaml.block.implementation.Section;
 import com.artillexstudios.axapi.serializers.Serializers;
@@ -106,6 +107,7 @@ public class Zone {
                 "%time-percent%", TimeUtils.fancyTimePercentage(rewardSeconds * 1_000L, rewardSeconds * 1_000L)
         ));
         zonePlayers.put(player, 0);
+        TrackingRangeManager.apply(player);
 
         Section section;
         if ((section = settings.getSection("in-zone.bossbar")) != null) {
@@ -135,6 +137,7 @@ public class Zone {
         it.remove();
         BossBar bossBar = bossbars.remove(player);
         if (bossBar != null) bossBar.remove();
+        TrackingRangeManager.reset(player);
     }
 
     private void sendTitle(Player player) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '${project.version}'
 main: com.artillexstudios.axafkzone.AxAFKZone
 api-version: '1.20'
 folia-supported: true
+depend: [ProtocolLib]
 
 permissions:
   axafkzone.admin:


### PR DESCRIPTION
## Summary
- integrate ProtocolLib
- add `TrackingRangeManager` to limit entity packets when players are in an AFK zone
- hook manager into plugin startup and zone enter/leave
- fix plugin description and add dependency

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bfdd76fa4832f8acfdcd5a2e6c7fd