### PR TITLE
Add distance reduction in AFK zones

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,12 @@ reset-after-reward: true
 # set to -1 for unlimited
 zone-per-ip-limit: -1
 
+# minimum view distance for players in an AFK zone
+min-view-distance: 2
+
+# minimum simulation distance for players in an AFK zone
+min-simulation-distance: 2
+
 # should the bossbar progress start from full or empty?
 # directions:
 # 0 - decreasing value (starts filled)
@@ -35,4 +41,4 @@ update-notifier:
   on-join: true
 
 # do not change this
-version: 2
+version: 3


### PR DESCRIPTION
## Summary
- lower player view & simulation distance while in AFK zone
- restore previous values on exit
- add config entries for minimal view & simulation distance

## Testing
- `mvn -q -DskipTests package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c03b94f58832fabfb7664fa8c1962